### PR TITLE
adds 0.5.0 version to the releases section of the appdata.xml file

### DIFF
--- a/fix-appdata-releases-version.patch
+++ b/fix-appdata-releases-version.patch
@@ -1,0 +1,12 @@
+diff --git a/runtime/nvim.appdata.xml b/runtime/nvim.appdata.xml
+index e99c76a93..099c9a57c 100644
+--- a/runtime/nvim.appdata.xml
++++ b/runtime/nvim.appdata.xml
+@@ -26,6 +26,7 @@
+   </screenshots>
+ 
+   <releases>
++    <release date="2021-07-02" version="0.5.0"/>
+     <release date="2020-08-04" version="0.4.4"/>
+     <release date="2019-11-06" version="0.4.3"/>
+     <release date="2019-09-15" version="0.4.2"/>

--- a/io.neovim.nvim.yaml
+++ b/io.neovim.nvim.yaml
@@ -250,6 +250,8 @@ modules:
           type: anitya
           project-id: 9037
           url-template: https://github.com/neovim/neovim/archive/v$version.tar.gz
+      - type: patch
+        path: fix-appdata-releases-version.patch
       - type: archive
         url: https://neovim.io/logos/neovim-logos.zip
         sha256: c899d052fb8c31b124746fc33bde5a23ff8b02d323b42a0dd8dd66b57b81d20d


### PR DESCRIPTION
This PR adds the 0.5.0 release number to the releases section of the runtime/nvim.appdata.xml on the upstream repo. The current release of upstream tagged as 0.5.0 does not include this, causing flatpak to report the version of neovim as being 0.4.4 even though the build is actually version 0.5.0.