### PR TITLE
Remove flathub.json to build aarch64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,0 @@
-{
-    "skip-arches": [
-        "aarch64"
-    ]
-}


### PR DESCRIPTION
I never realized but with #16 I forgot to actually reenable `aarch64`. 