### PR TITLE
implements ide-flatpak-wrapper support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wrapper"]
+	path = wrapper
+	url = https://github.com/flathub/ide-flatpak-wrapper

--- a/io.neovim.nvim.yaml
+++ b/io.neovim.nvim.yaml
@@ -5,7 +5,7 @@ runtime: org.freedesktop.Sdk
 runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
 
-command: nvim
+command: nvim-wrapper
 rename-desktop-file: nvim.desktop
 rename-icon: nvim
 
@@ -253,6 +253,22 @@ modules:
           url-template: https://github.com/neovim/neovim/archive/v$version.tar.gz
       - type: patch
         path: fix-appdata-releases-version.patch
+      - type: patch
+        path: nvim.desktop-exec-wrapper.patch
       - type: archive
         url: https://neovim.io/logos/neovim-logos.zip
         sha256: c899d052fb8c31b124746fc33bde5a23ff8b02d323b42a0dd8dd66b57b81d20d
+
+  - name: wrapper
+    buildsystem: meson
+    sources:
+      - type: dir
+        path: wrapper
+      - type: file
+        path: neovim-first-run.txt
+    config-opts:
+      - -Deditor_binary=/app/bin/nvim
+      - -Dprogram_name=nvim-wrapper
+      - -Deditor_title=Neo Vim
+      - -Dfirst_run_template=neovim-first-run.txt
+      - -Dflagfile_prefix=flatpak-neovim

--- a/neovim-first-run.txt
+++ b/neovim-first-run.txt
@@ -1,0 +1,31 @@
+
+https://www.flathub.org
+
+------------------------------------------------------------------------------------
+| Warning: You are running an unofficial Flatpak version of @EDITOR_TITLE@ !!! |
+------------------------------------------------------------------------------------
+
+Please open issues under: https://github.com/flathub/@FLATPAK_ID@/issues
+
+
+This version is running inside a container and is therefore not able
+to access SDKs on your host system!
+
+This flatpak provides a standard development environment (gcc, python, etc).
+To see what's available:
+
+  $ flatpak run --command=sh @FLATPAK_ID@
+  $ ls /usr/bin (shared runtime)
+  $ ls /app/bin (bundled with this flatpak)
+
+To get support for additional languages, you have to install SDK extensions, e.g.
+
+  $ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
+  $ flatpak install flathub org.freedesktop.Sdk.Extension.golang
+  $ FLATPAK_ENABLE_SDK_EXT=dotnet,golang flatpak run @FLATPAK_ID@
+
+You can use
+
+  $ flatpak search <TEXT>
+
+to find others.

--- a/nvim.desktop-exec-wrapper.patch
+++ b/nvim.desktop-exec-wrapper.patch
@@ -1,0 +1,15 @@
+diff --git a/runtime/nvim.desktop b/runtime/nvim.desktop
+index 052904dd7..b6768258b 100644
+--- a/runtime/nvim.desktop
++++ b/runtime/nvim.desktop
+@@ -74,8 +74,8 @@ Comment[vi]=Soạn thảo tập tin văn bản
+ Comment[wa]=Asspougnî des fitchîs tecses
+ Comment[zh_CN]=编辑文本文件
+ Comment[zh_TW]=編輯文字檔
+-TryExec=nvim
+-Exec=nvim %F
++TryExec=nvim-wrapper
++Exec=nvim-wrapper %F
+ Terminal=true
+ Type=Application
+ Keywords=Text;editor;


### PR DESCRIPTION
This pull request fixes #17 

It uses the https://github.com/flathub/ide-flatpak-wrapper/ module to enable SDK extensions in this flatpak using the environment variable FLATPAK_ENABLE_SDK_EXT.

For example, if one needed access to a nodejs executable inside of the flatpak runtime (for using Coc.nvim, for example) you could simply install the "org.freedesktop.Sdk.Extension.node14" flatpak and then set the environment variable to "FLATPAK_ENABLE_SDK_EXT=node14". This PR also adds a help text file that is opened on neovim's first initialization which explains to the user what they need to do to install SDK extensions.

This behavior is what is already implemented in the faltpaks for VSCode and Emacs.