### PR TITLE
enhanc: Enable SDK - Make the enablement persist

### DIFF
--- a/neovim-first-run.txt
+++ b/neovim-first-run.txt
@@ -22,7 +22,7 @@ To get support for additional languages, you have to install SDK extensions, e.g
 
   $ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
   $ flatpak install flathub org.freedesktop.Sdk.Extension.golang
-  $ sudo flatpak override --env=FLATPAK_ENABLE_SDK_EXT=dotnet,golang @FLATPAK_ID@
+  $ flatpak override --user --env=FLATPAK_ENABLE_SDK_EXT=dotnet,golang @FLATPAK_ID@
 
 You can use
 

--- a/neovim-first-run.txt
+++ b/neovim-first-run.txt
@@ -22,7 +22,7 @@ To get support for additional languages, you have to install SDK extensions, e.g
 
   $ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
   $ flatpak install flathub org.freedesktop.Sdk.Extension.golang
-  $ FLATPAK_ENABLE_SDK_EXT=dotnet,golang flatpak run @FLATPAK_ID@
+  $ sudo flatpak override --env=FLATPAK_ENABLE_SDK_EXT=dotnet,golang @FLATPAK_ID@
 
 You can use
 


### PR DESCRIPTION
This environment variable only persists within the session. To make it persistent it is necessary to use the flatpak override. 