### PR TITLE
Update runtime version

### DIFF
--- a/io.neovim.nvim.yaml
+++ b/io.neovim.nvim.yaml
@@ -1,7 +1,7 @@
 app-id: io.neovim.nvim
 
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 
 command: nvim-wrapper


### PR DESCRIPTION
Version 22.08 provides news like Python 3.10+
closes: #43