### PR TITLE
Update wrapper and use -Ddefault_loglevel option

### DIFF
--- a/io.neovim.nvim.yaml
+++ b/io.neovim.nvim.yaml
@@ -286,3 +286,4 @@ modules:
       - -Dfirst_run_template=neovim-first-run.txt
       - -Dsdk_update_template=neovim-sdk-update.txt
       - -Dflagfile_prefix=flatpak-neovim
+      - -Ddefault_loglevel=0


### PR DESCRIPTION
That will suppress output from wrapper unless user sets FLATPAK_IDE_LOGLEVEL=1 env variable

This will close #34 