### PR TITLE
Override TERMINFO_DIRS to prefer host terminfo files over builtin ones

### DIFF
--- a/io.neovim.nvim.yaml
+++ b/io.neovim.nvim.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --filesystem=host
   - --filesystem=/tmp
   - --filesystem=/var/tmp
+  - --env=TERMINFO_DIRS='/var/run/host/usr/share/terminfo:/usr/share/terminfo'
   # Plugin updates
   - --share=network
   # Clipboard access


### PR DESCRIPTION
This would make using terminals like kitty, wezterm, etc that use custom terminfo painless and possibly prevent issues with mismatch of terminfo versions as the terminfo that comes with the terminal is used