### PR TITLE
fix: add `%F` code to Exec key in Desktop Entry

### DIFF
--- a/io.neovim.nvim.yaml
+++ b/io.neovim.nvim.yaml
@@ -255,7 +255,7 @@ modules:
       # Install icon
       - install -Dm644 ../neovim-mark.svg /app/share/icons/hicolor/scalable/apps/nvim.svg
       # Set desktop
-      - desktop-file-edit --set-key=Exec --set-value=nvim-wrapper /app/share/applications/nvim.desktop
+      - desktop-file-edit --set-key=Exec --set-value="nvim-wrapper %F" /app/share/applications/nvim.desktop
       # Create directory for tool
       - install -d "${FLATPAK_DEST}/tools"
     sources:


### PR DESCRIPTION
The `%F` code is defined in the [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) as 'A list of files. Use for apps that can open several local files at once.' This PR makes Flatpak export the desktop entry file with the `--file-forwarding` flag.

It looks like it is working as expected and without any drawbacks when building locally with the command `flatpak-builder --user --install --force-clean build-dir io.neovim.nvim.yml` from [here](https://docs.flatpak.org/en/latest/first-build.html).

Fix #63